### PR TITLE
Changes to allow POMP handle guard pages correctly

### DIFF
--- a/reverse-from-coredump/src/access_memory.c
+++ b/reverse-from-coredump/src/access_memory.c
@@ -189,6 +189,13 @@ int address_writable(elf_core_info* core_info, Elf32_Addr address){
         return (core_info->phdr[segment].p_flags & PF_W) ? 1:0;
 }
 
+int address_readable(elf_core_info* core_info, Elf32_Addr address){
+        int segment;
+        if((segment = address_segment(core_info, address))<0)
+                return 0;
+        return (core_info->phdr[segment].p_flags & PF_R) ? 1:0;
+}
+
 int addr_in_segment(GElf_Phdr phdr, Elf32_Addr addr){
 	if(addr >= phdr.p_vaddr && addr < phdr.p_vaddr + phdr.p_memsz)
 		return 1;

--- a/reverse-from-coredump/src/process_thread.c
+++ b/reverse-from-coredump/src/process_thread.c
@@ -58,6 +58,10 @@ int single_op_legal_access(x86_insn_t *insn, x86_op_t *opd, struct elf_prstatus 
 		if ((opd -> access & op_write) && (!address_writable(core_info, target))) {
 			legal = 0;
 		}
+		
+		if ((opd -> access & op_read) && (!address_readable(core_info, target))) {
+                        legal = 0;
+		}
 	}
 	return legal;
 }


### PR DESCRIPTION
POMP is unable to handle the guard pages i.e., pages with no access permissions introduced by libdislocator. 
Suggested change allows POMP to gracefully handle accesses to guard pages. 